### PR TITLE
have both versions of service point to the same app

### DIFF
--- a/v1/guestbook-deployment.yaml
+++ b/v1/guestbook-deployment.yaml
@@ -1,9 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: guestbook
+  name: guestbook-v1
   labels:
     app: guestbook
+    version: "1.0"
 spec:
   replicas: 3
   selector:

--- a/v2/guestbook-deployment.yaml
+++ b/v2/guestbook-deployment.yaml
@@ -3,17 +3,17 @@ kind: Deployment
 metadata:
   name: guestbook-v2
   labels:
-    app: guestbook-v2
+    app: guestbook
     version: "2.0"
 spec:
   selector:
     matchLabels:
-      app: guestbook-v2
+      app: guestbook
   replicas: 3
   template:
     metadata:
       labels:
-        app: guestbook-v2
+        app: guestbook
         version: "2.0"
     spec:
       containers:
@@ -26,4 +26,3 @@ spec:
         ports:
         - name: http
           containerPort: 3000
-

--- a/v2/guestbook-service.yaml
+++ b/v2/guestbook-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: guestbook
   labels:
-    app: guestbook-v2
+    app: guestbook
 spec:
   # comment or delete the following line if you want to use a LoadBalancer
   # type: NodePort
@@ -15,4 +15,4 @@ spec:
     targetPort: 3000
     name: http
   selector:
-    app: guestbook-v2
+    app: guestbook


### PR DESCRIPTION
Bug fix for istio101 course.  https://github.com/IBM/istio101/blob/master/workshop/exercise-3/README.md#install-the-guestbook-app-with-manual-sidecar-injection attempts to have two k8s deployments for guestbook service and only one k8s service definition.  The v1 and v2 deployment files have different app selectors have two different values so this currently does not work.
https://github.com/IBM/guestbook/blob/master/v2/guestbook-deployment.yaml#L11
and
https://github.com/IBM/guestbook/blob/master/v1/guestbook-deployment.yaml#L6

Also modified v1 deployment yaml so that pod names are of the form `guestbook-v1-XXXXXX` instead of `guestbook-XXXXXX` to better clarify different service versions