### PR TITLE
version needs to be in template section too

### DIFF
--- a/v1/guestbook-deployment.yaml
+++ b/v1/guestbook-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         app: guestbook
+        version: "1.0"
     spec:
       containers:
       - name: guestbook


### PR DESCRIPTION
follow up this PR: https://github.com/IBM/guestbook/pull/32
missed one section where `version: "1.0"` is needed