### PR TITLE
quotes are needed for istio auto injection to work

### DIFF
--- a/v2/analyzer-deployment.yaml
+++ b/v2/analyzer-deployment.yaml
@@ -23,11 +23,11 @@ spec:
             cpu: 100m
             memory: 100Mi
         env:
-        #- name: "VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_USERNAME"
+        #- name: VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_USERNAME
         #  value: "..."
-        #- name: "VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_PASSWORD"
+        #- name: VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_PASSWORD
         #  value: "..."
-        - name: "USE_HTTPS"
+        - name: USE_HTTPS
           value: "True"
         ports:
         - containerPort: 5000

--- a/v2/analyzer-deployment.yaml
+++ b/v2/analyzer-deployment.yaml
@@ -23,12 +23,12 @@ spec:
             cpu: 100m
             memory: 100Mi
         env:
-        #- name: VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_USERNAME
-        #  value: ...
-        #- name: VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_PASSWORD
-        #  value: ...
-        - name: USE_HTTPS
-          value: True
+        #- name: "VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_USERNAME"
+        #  value: "..."
+        #- name: "VCAP_SERVICES_TONE_ANALYZER_0_CREDENTIALS_PASSWORD"
+        #  value: "..."
+        - name: "USE_HTTPS"
+          value: "True"
         ports:
         - containerPort: 5000
           name: http


### PR DESCRIPTION
Else, we'd get errors like when using auto injection feature.

$ kubectl create -f analyzer-deployment.yaml
Error from server (BadRequest): error when creating "analyzer-deployment.yaml": Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true}],"ima|..., bigger context ...|lue":"OsgpTOjH8SYN"},{"name":"USE_HTTPS","value":true}],"image":"ibmcom/analyzer:v1","imagePullPolic|...

