### PR TITLE
Update egress with wildcard value for tone analyzer

### DIFF
--- a/v2/analyzer-deployment.yaml
+++ b/v2/analyzer-deployment.yaml
@@ -24,11 +24,11 @@ spec:
             memory: 100Mi
         env:
         - name: VCAP_SERVICES_TONE_ANALYZER_API_KEY
-          value:
+          value: YOUR_API_KEY
         - name : VCAP_SERVICES_TONE_ANALYZER_TOKEN_ADDRESS
           value: "iam.bluemix.net/identity/token"
         - name: VCAP_SERVICES_TONE_ANALYZER_SERVICE_API
-          value:
+          value: YOUR_URL
         - name: USE_HTTPS
           value: "True"
         ports:

--- a/v2/analyzer-egress.yaml
+++ b/v2/analyzer-egress.yaml
@@ -37,12 +37,12 @@ metadata:
   name: watson
 spec:
   hosts:
-  - gateway.watsonplatform.net
+  - "*.watsonplatform.net"
   ports:
   - number: 443
     name: https
     protocol: HTTPS
-  resolution: DNS
+  resolution: NONE
   location: MESH_EXTERNAL
 ---
 apiVersion: networking.istio.io/v1alpha3
@@ -51,15 +51,15 @@ metadata:
   name: watson
 spec:
   hosts:
-  - gateway.watsonplatform.net
+  - "*.watsonplatform.net"
   tls:
   - match:
     - port: 443
       sni_hosts:
-      - gateway.watsonplatform.net
+      - "*.watsonplatform.net"
     route:
     - destination:
-        host: gateway.watsonplatform.net
+        host: "*.watsonplatform.net"
         port:
           number: 443
       weight: 100


### PR DESCRIPTION
this pr updates the egress rules with a wildcard value, since tone analyzer has a different api url dependent on what region the service is provisioned in.