### PR TITLE
Update redis-slave-deployment.yaml

### DIFF
--- a/v1/redis-slave-deployment.yaml
+++ b/v1/redis-slave-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-slave
-        image: kubernetes/redis-slave:v2
+        image: ibmcom/guestbook-redis-slave:v2
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
kubernetes/redis-slave:v2 no longer exists