### PR TITLE
match redis version in master to slave

### DIFF
--- a/v1/redis-master-deployment.yaml
+++ b/v1/redis-master-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: redis:2.8.23
+        image: redis:3.2.9
         ports:
         - name: redis-server
           containerPort: 6379

--- a/v2/redis-master-deployment.yaml
+++ b/v2/redis-master-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: redis:2.8.23
+        image: redis:3.2.9
         ports:
         - name: redis-server
           containerPort: 6379

--- a/v2/redis-slave-deployment.yaml
+++ b/v2/redis-slave-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-slave
-        image: kubernetes/redis-slave:v2
+        image: ibmcom/guestbook-redis-slave:v2
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
Update redis image version to match `ibmcom/redis-slave:v2` (3.2.9 from upstream kubernetes example). Correct slave image spec for v2.

fixes #65  in master branch