### PR TITLE
Use same Redis version in master as slave

### DIFF
--- a/v2/redis-master-deployment.yaml
+++ b/v2/redis-master-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: redis-master
-        image: redis:2.8.23
+        image: redis:3.2.9
         ports:
         - name: redis-server
           containerPort: 6379


### PR DESCRIPTION
version 3.2.9 was implicitly updated in slave but not in master